### PR TITLE
Fix ESM relative import extensions

### DIFF
--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -1,6 +1,6 @@
-import { assertSameLength, makeSeries, mean, stdev } from "./math";
-import { hlc3 } from "./overlap";
-import { realizedVolatility } from "./performance";
+import { assertSameLength, makeSeries, mean, stdev } from "./math.js";
+import { hlc3 } from "./overlap.js";
+import { realizedVolatility } from "./performance.js";
 
 export function vwapSession(
   high: number[],
@@ -126,3 +126,4 @@ export function orderflowImbalance(
   }
   return out;
 }
+

--- a/src/core/momentum.ts
+++ b/src/core/momentum.ts
@@ -1,5 +1,5 @@
-﻿import { makeSeries } from "./math";
-import { ema } from "./overlap";
+import { makeSeries } from "./math.js";
+import { ema } from "./overlap.js";
 
 export function macd(values: number[], fast = 12, slow = 26, signal = 9) {
   const fastEma = ema(values, fast);
@@ -87,3 +87,4 @@ export function stoch(
 
   return { k, d };
 }
+

--- a/src/core/overlap.ts
+++ b/src/core/overlap.ts
@@ -1,4 +1,4 @@
-﻿import { assertSameLength, isNum, makeSeries, mean, stdev } from "./math";
+import { assertSameLength, isNum, makeSeries, mean, stdev } from "./math.js";
 
 export function sma(values: number[], length = 14): Array<number | null> {
   const out = makeSeries(values.length);
@@ -107,3 +107,4 @@ export function bbands(values: number[], length = 20, std = 2) {
   }
   return { basis, upper, lower };
 }
+

--- a/src/core/performance.ts
+++ b/src/core/performance.ts
@@ -1,4 +1,4 @@
-﻿import { makeSeries, stdev } from "./math";
+import { makeSeries, stdev } from "./math.js";
 
 export function logReturn(values: number[], cumulative = false): Array<number | null> {
   const out = makeSeries(values.length);
@@ -39,3 +39,4 @@ export function realizedVolatility(values: number[], length = 30, periodsPerYear
   }
   return out;
 }
+

--- a/src/core/trend.ts
+++ b/src/core/trend.ts
@@ -1,6 +1,6 @@
-import { makeSeries } from "./math";
-import { rma } from "./overlap";
-import { trueRange } from "./volatility";
+import { makeSeries } from "./math.js";
+import { rma } from "./overlap.js";
+import { trueRange } from "./volatility.js";
 
 export function adx(high: number[], low: number[], close: number[], length = 14) {
   const len = close.length;
@@ -44,3 +44,4 @@ export function adx(high: number[], low: number[], close: number[], length = 14)
 
   return { adx, plusDI, minusDI };
 }
+

--- a/src/core/volatility.ts
+++ b/src/core/volatility.ts
@@ -1,5 +1,5 @@
-﻿import { assertSameLength, makeSeries } from "./math";
-import { rma } from "./overlap";
+import { assertSameLength, makeSeries } from "./math.js";
+import { rma } from "./overlap.js";
 
 export function trueRange(high: number[], low: number[], close: number[]): Array<number | null> {
   assertSameLength(high, low, close);
@@ -33,3 +33,4 @@ export function natr(high: number[], low: number[], close: number[], length = 14
   }
   return out;
 }
+

--- a/src/core/volume.ts
+++ b/src/core/volume.ts
@@ -1,4 +1,4 @@
-import { makeSeries } from "./math";
+import { makeSeries } from "./math.js";
 
 export function obv(close: number[], volume: number[]): Array<number | null> {
   if (close.length !== volume.length) {
@@ -57,3 +57,4 @@ export function mfi(
 
   return out;
 }
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-﻿export { sma, ema, rma, hl2, hlc3, ohlc4, vwap, bbands } from "./core/overlap";
-export { rsi, macd, stoch } from "./core/momentum";
-export { trueRange, atr, natr } from "./core/volatility";
-export { logReturn, percentReturn, realizedVolatility } from "./core/performance";
-export { obv, mfi } from "./core/volume";
-export { adx } from "./core/trend";
+export { sma, ema, rma, hl2, hlc3, ohlc4, vwap, bbands } from "./core/overlap.js";
+export { rsi, macd, stoch } from "./core/momentum.js";
+export { trueRange, atr, natr } from "./core/volatility.js";
+export { logReturn, percentReturn, realizedVolatility } from "./core/performance.js";
+export { obv, mfi } from "./core/volume.js";
+export { adx } from "./core/trend.js";
 export {
   vwapSession,
   fundingRateCumulative,
@@ -12,16 +12,16 @@ export {
   signedVolume,
   volumeDelta,
   orderflowImbalance
-} from "./core/crypto";
-export * from "./types";
+} from "./core/crypto.js";
+export * from "./types.js";
 
-import * as overlap from "./core/overlap";
-import * as momentum from "./core/momentum";
-import * as volatility from "./core/volatility";
-import * as performance from "./core/performance";
-import * as volume from "./core/volume";
-import * as trend from "./core/trend";
-import * as crypto from "./core/crypto";
+import * as overlap from "./core/overlap.js";
+import * as momentum from "./core/momentum.js";
+import * as volatility from "./core/volatility.js";
+import * as performance from "./core/performance.js";
+import * as volume from "./core/volume.js";
+import * as trend from "./core/trend.js";
+import * as crypto from "./core/crypto.js";
 
 export const ta = {
   ...overlap,
@@ -32,3 +32,4 @@ export const ta = {
   ...trend,
   ...crypto
 };
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 ﻿{
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "NodeNext",
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true


### PR DESCRIPTION
  ## What
  - Fix ESM relative imports by adding `.js` extensions across `src`
  - Align TypeScript config to Node ESM (`module`/`moduleResolution` = `NodeNext`)

  ## Why
  Node ESM requires explicit file extensions for relative imports. The current build emits
  extensionless imports (e.g. `./core/overlap`), which fails at runtime with `ERR_MODULE_NOT_FOUND`.

  ## How
  - Update all internal relative imports to include `.js`
  - Adjust TS config to `NodeNext` to match Node ESM behavior

  ## Tests
  - npm test (no tests yet)
  - npm run build