### PR TITLE
feat: add shared rolling-window engine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ npm run test:compat:technicalindicators
 # python deps: pip install -r scripts/requirements-compat.txt
 npm run test:compat:python
 npm run bench
+npm run bench:rolling
 ```
 
 ## Code standards
@@ -66,6 +67,7 @@ npm run bench
 
 1. Extend `scripts/bench.js` with realistic input sizes.
 2. Include before/after numbers and methodology in the PR description.
+3. For rolling-window changes, preserve the warmup and alignment invariants in `docs/rolling-engine.md`.
 
 ### Examples
 

--- a/docs/rolling-engine.md
+++ b/docs/rolling-engine.md
@@ -1,0 +1,30 @@
+# Rolling engine invariants
+
+The internal rolling engine in `src/core/rolling.ts` centralizes fixed-window sum, mean, population standard deviation, minimum, and maximum calculations.
+
+## Behavior
+
+- A window of period `N` returns `null` for its first `N - 1` updates.
+- The first numeric result includes input indices `0..N - 1`.
+- Every later result removes exactly the oldest value before including the newest value.
+- `reset()` restores a newly constructed engine's state.
+- Periods must be positive integers. Stateful primitive inputs must be finite numbers; public batch APIs retain their existing validation layer.
+- Standard deviation uses population variance, matching the existing `bbands` behavior.
+
+These rules preserve the library's established warmup and alignment semantics. The engine is internal for now; public indicator APIs remain unchanged.
+
+## Complexity
+
+Rolling sum, mean, and standard deviation use a fixed-size circular buffer and update in constant time. Rolling minimum and maximum use monotonic queues with amortized constant-time updates. Storage is bounded by the configured period.
+
+## Verification
+
+Run the behavioral suite and focused deterministic benchmark:
+
+```bash
+npm test
+npm run test:golden
+npm run bench:rolling
+```
+
+The focused benchmark reports `sma` and `bbands` runs for both 10,000 and 100,000 values against their previous implementations.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "generate:golden": "npm run build && node ./scripts/generate-golden.js",
     "generate:compat": "npm run build && node ./scripts/export-compat-vectors.js",
     "bench": "npm run build && node ./scripts/bench.js",
+    "bench:rolling": "npm run build && node ./scripts/bench-rolling.js",
     "test": "npm run build && node --test test/*.test.mjs",
     "test:golden": "npm run build && node --test test/golden.test.mjs",
     "test:compat:technicalindicators": "npm run generate:compat && node ./scripts/compare-technicalindicators.js",

--- a/scripts/bench-rolling.js
+++ b/scripts/bench-rolling.js
@@ -1,0 +1,76 @@
+import { performance } from "node:perf_hooks";
+import { bbands, sma } from "../dist/core/overlap.js";
+
+function makeSeries(length, start = 100) {
+  const values = new Array(length);
+  let value = start;
+  for (let i = 0; i < length; i++) {
+    value += Math.sin(i * 0.017) * 0.7 + Math.cos(i * 0.003) * 0.2;
+    values[i] = value;
+  }
+  return values;
+}
+
+function measure(fn, runs) {
+  fn();
+  const started = performance.now();
+  for (let i = 0; i < runs; i++) fn();
+  return (performance.now() - started) / runs;
+}
+
+function legacySum(values, start, end) {
+  let total = 0;
+  for (let i = start; i <= end; i++) total += values[i];
+  return total;
+}
+
+function legacyMean(values, start, end) {
+  return legacySum(values, start, end) / (end - start + 1);
+}
+
+function legacyStdDev(values, start, end) {
+  const mean = legacyMean(values, start, end);
+  let squared = 0;
+  for (let i = start; i <= end; i++) {
+    const delta = values[i] - mean;
+    squared += delta * delta;
+  }
+  return Math.sqrt(squared / (end - start + 1));
+}
+
+function legacySma(values, period) {
+  const out = new Array(values.length).fill(null);
+  for (let i = period - 1; i < values.length; i++) {
+    out[i] = legacyMean(values, i - period + 1, i);
+  }
+  return out;
+}
+
+function legacyBbands(values, period, deviations) {
+  const basis = legacySma(values, period);
+  const upper = new Array(values.length).fill(null);
+  const lower = new Array(values.length).fill(null);
+  for (let i = period - 1; i < values.length; i++) {
+    const deviation = legacyStdDev(values, i - period + 1, i);
+    upper[i] = basis[i] + deviations * deviation;
+    lower[i] = basis[i] - deviations * deviation;
+  }
+  return { basis, upper, lower };
+}
+
+function report(name, length, before, after) {
+  const runs = length === 10_000 ? 30 : 5;
+  const beforeMs = measure(before, runs);
+  const afterMs = measure(after, runs);
+  const speedup = beforeMs / afterMs;
+  console.log(
+    `${String(length).padStart(6)} ${name.padEnd(12)} before=${beforeMs.toFixed(3)} ms ` +
+    `after=${afterMs.toFixed(3)} ms speedup=${speedup.toFixed(2)}x`
+  );
+}
+
+for (const length of [10_000, 100_000]) {
+  const close = makeSeries(length);
+  report("sma(20)", length, () => legacySma(close, 20), () => sma(close, 20));
+  report("bbands(20)", length, () => legacyBbands(close, 20, 2), () => bbands(close, 20, 2));
+}

--- a/src/core/overlap.ts
+++ b/src/core/overlap.ts
@@ -1,12 +1,9 @@
-import { assertSameLength, isNum, makeSeries, mean, stdev } from "./math.js";
+import { assertSameLength, isNum, makeSeries, mean } from "./math.js";
+import { rollingMean, rollingMeanStdDev } from "./rolling.js";
 
 export function sma(values: number[], length = 14): Array<number | null> {
-  const out = makeSeries(values.length);
-  if (length <= 0) return out;
-  for (let i = length - 1; i < values.length; i++) {
-    out[i] = mean(values, i - length + 1, i);
-  }
-  return out;
+  if (length <= 0) return makeSeries(values.length);
+  return rollingMean(values, length);
 }
 
 export function ema(values: number[], length = 14): Array<number | null> {
@@ -97,14 +94,20 @@ export function vwap(
 }
 
 export function bbands(values: number[], length = 20, std = 2) {
-  const basis = sma(values, length);
-  const upper = makeSeries(values.length);
+  if (length <= 0) {
+    return {
+      basis: makeSeries(values.length),
+      upper: makeSeries(values.length),
+      lower: makeSeries(values.length)
+    };
+  }
+  const { mean: basis, stdDev: upper } = rollingMeanStdDev(values, length);
   const lower = makeSeries(values.length);
-  for (let i = length - 1; i < values.length; i++) {
-    const s = stdev(values, i - length + 1, i);
+  for (let i = 0; i < values.length; i++) {
+    const s = upper[i];
+    if (s === null) continue;
     upper[i] = (basis[i] as number) + std * s;
     lower[i] = (basis[i] as number) - std * s;
   }
   return { basis, upper, lower };
 }
-

--- a/src/core/rolling.ts
+++ b/src/core/rolling.ts
@@ -1,0 +1,258 @@
+export type RollingValue = number | null;
+
+function assertPeriod(period: number): void {
+  if (!Number.isInteger(period) || period <= 0) {
+    throw new Error("period must be a positive integer");
+  }
+}
+
+function assertValue(value: number): void {
+  if (!Number.isFinite(value)) {
+    throw new Error("value must be a finite number");
+  }
+}
+
+export class RollingWindow {
+  readonly period: number;
+  private readonly values: number[];
+  private cursor = 0;
+  private count = 0;
+
+  constructor(period: number) {
+    assertPeriod(period);
+    this.period = period;
+    this.values = new Array<number>(period);
+  }
+
+  get size(): number {
+    return this.count;
+  }
+
+  get ready(): boolean {
+    return this.count === this.period;
+  }
+
+  push(value: number): number | null {
+    assertValue(value);
+    const removed = this.ready ? this.values[this.cursor] : null;
+    this.values[this.cursor] = value;
+    this.cursor = (this.cursor + 1) % this.period;
+    if (this.count < this.period) this.count += 1;
+    return removed;
+  }
+
+  reset(): void {
+    this.cursor = 0;
+    this.count = 0;
+  }
+}
+
+export class RollingSum {
+  private readonly window: RollingWindow;
+  private total = 0;
+
+  constructor(period: number) {
+    this.window = new RollingWindow(period);
+  }
+
+  get ready(): boolean {
+    return this.window.ready;
+  }
+
+  next(value: number): RollingValue {
+    const removed = this.window.push(value);
+    this.total += value - (removed ?? 0);
+    return this.ready ? this.total : null;
+  }
+
+  reset(): void {
+    this.window.reset();
+    this.total = 0;
+  }
+}
+
+export class RollingMean {
+  readonly period: number;
+  private readonly sum: RollingSum;
+
+  constructor(period: number) {
+    assertPeriod(period);
+    this.period = period;
+    this.sum = new RollingSum(period);
+  }
+
+  next(value: number): RollingValue {
+    const total = this.sum.next(value);
+    return total === null ? null : total / this.period;
+  }
+
+  reset(): void {
+    this.sum.reset();
+  }
+}
+
+export class RollingStdDev {
+  readonly period: number;
+  private readonly window: RollingWindow;
+  private total = 0;
+  private totalSquares = 0;
+
+  constructor(period: number) {
+    assertPeriod(period);
+    this.period = period;
+    this.window = new RollingWindow(period);
+  }
+
+  next(value: number): RollingValue {
+    const removed = this.window.push(value);
+    this.total += value - (removed ?? 0);
+    this.totalSquares += value * value - (removed === null ? 0 : removed * removed);
+    if (!this.window.ready) return null;
+
+    const mean = this.total / this.period;
+    const variance = Math.max(0, this.totalSquares / this.period - mean * mean);
+    return Math.sqrt(variance);
+  }
+
+  reset(): void {
+    this.window.reset();
+    this.total = 0;
+    this.totalSquares = 0;
+  }
+}
+
+type ExtremumEntry = { index: number; value: number };
+
+class RollingExtremum {
+  private readonly period: number;
+  private readonly compare: (candidate: number, tail: number) => boolean;
+  private readonly deque: ExtremumEntry[] = [];
+  private head = 0;
+  private index = -1;
+
+  constructor(period: number, compare: (candidate: number, tail: number) => boolean) {
+    assertPeriod(period);
+    this.period = period;
+    this.compare = compare;
+  }
+
+  next(value: number): RollingValue {
+    assertValue(value);
+    this.index += 1;
+    const firstValid = this.index - this.period + 1;
+    while (this.head < this.deque.length && this.deque[this.head].index < firstValid) this.head += 1;
+    while (this.deque.length > this.head && this.compare(value, this.deque[this.deque.length - 1].value)) {
+      this.deque.pop();
+    }
+    this.deque.push({ index: this.index, value });
+
+    if (this.head > 64 && this.head * 2 > this.deque.length) {
+      this.deque.splice(0, this.head);
+      this.head = 0;
+    }
+    return this.index + 1 < this.period ? null : this.deque[this.head].value;
+  }
+
+  reset(): void {
+    this.deque.length = 0;
+    this.head = 0;
+    this.index = -1;
+  }
+}
+
+export class RollingMin extends RollingExtremum {
+  constructor(period: number) {
+    super(period, (candidate, tail) => candidate <= tail);
+  }
+}
+
+export class RollingMax extends RollingExtremum {
+  constructor(period: number) {
+    super(period, (candidate, tail) => candidate >= tail);
+  }
+}
+
+function collect(values: number[], engine: { next(value: number): RollingValue }): RollingValue[] {
+  return values.map(value => engine.next(value));
+}
+
+export function rollingSum(values: number[], period: number): RollingValue[] {
+  assertPeriod(period);
+  const out = new Array<RollingValue>(values.length).fill(null);
+  let total = 0;
+  for (let i = 0; i < values.length; i++) {
+    total += values[i];
+    if (i >= period) total -= values[i - period];
+    if (i >= period - 1) out[i] = total;
+  }
+  return out;
+}
+
+export function rollingMean(values: number[], period: number): RollingValue[] {
+  assertPeriod(period);
+  const out = new Array<RollingValue>(values.length).fill(null);
+  let total = 0;
+  for (let i = 0; i < values.length; i++) {
+    total += values[i];
+    if (i >= period) total -= values[i - period];
+    if (i >= period - 1) out[i] = total / period;
+  }
+  return out;
+}
+
+export function rollingStdDev(values: number[], period: number): RollingValue[] {
+  assertPeriod(period);
+  const out = new Array<RollingValue>(values.length).fill(null);
+  let total = 0;
+  let totalSquares = 0;
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i];
+    total += value;
+    totalSquares += value * value;
+    if (i >= period) {
+      const removed = values[i - period];
+      total -= removed;
+      totalSquares -= removed * removed;
+    }
+    if (i >= period - 1) {
+      const mean = total / period;
+      out[i] = Math.sqrt(Math.max(0, totalSquares / period - mean * mean));
+    }
+  }
+  return out;
+}
+
+export function rollingMeanStdDev(
+  values: number[],
+  period: number
+): { mean: RollingValue[]; stdDev: RollingValue[] } {
+  assertPeriod(period);
+  const mean = new Array<RollingValue>(values.length).fill(null);
+  const stdDev = new Array<RollingValue>(values.length).fill(null);
+  let total = 0;
+  let totalSquares = 0;
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i];
+    total += value;
+    totalSquares += value * value;
+    if (i >= period) {
+      const removed = values[i - period];
+      total -= removed;
+      totalSquares -= removed * removed;
+    }
+    if (i >= period - 1) {
+      const currentMean = total / period;
+      mean[i] = currentMean;
+      stdDev[i] = Math.sqrt(Math.max(0, totalSquares / period - currentMean * currentMean));
+    }
+  }
+  return { mean, stdDev };
+}
+
+export function rollingMin(values: number[], period: number): RollingValue[] {
+  return collect(values, new RollingMin(period));
+}
+
+export function rollingMax(values: number[], period: number): RollingValue[] {
+  return collect(values, new RollingMax(period));
+}

--- a/src/stateful.ts
+++ b/src/stateful.ts
@@ -1,3 +1,5 @@
+import { RollingMean } from "./core/rolling.js";
+
 export type StatefulIndicator<TIn, TOut> = {
   next(value: TIn): TOut;
   reset(): void;
@@ -8,8 +10,7 @@ export function createSMA(period = 14): StatefulIndicator<number, number | null>
     throw new Error("period must be > 0");
   }
 
-  const window: number[] = [];
-  let sum = 0;
+  const rolling = new RollingMean(period);
 
   return {
     next(value: number): number | null {
@@ -17,20 +18,10 @@ export function createSMA(period = 14): StatefulIndicator<number, number | null>
         throw new Error("value must be a finite number");
       }
 
-      window.push(value);
-      sum += value;
-
-      if (window.length < period) {
-        return null;
-      }
-      if (window.length > period) {
-        sum -= window.shift() as number;
-      }
-      return sum / period;
+      return rolling.next(value);
     },
     reset(): void {
-      window.length = 0;
-      sum = 0;
+      rolling.reset();
     }
   };
 }

--- a/test/rolling.test.mjs
+++ b/test/rolling.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  RollingMax,
+  RollingMean,
+  RollingMin,
+  RollingStdDev,
+  RollingSum,
+  rollingMax,
+  rollingMean,
+  rollingMin,
+  rollingStdDev,
+  rollingSum
+} from "../dist/core/rolling.js";
+
+const values = [4, 2, 8, 6, 10];
+
+test("rolling batch helpers preserve warmup and window alignment", () => {
+  assert.deepEqual(rollingSum(values, 3), [null, null, 14, 16, 24]);
+  assert.deepEqual(rollingMean(values, 3), [null, null, 14 / 3, 16 / 3, 8]);
+  assert.deepEqual(rollingMin(values, 3), [null, null, 2, 2, 6]);
+  assert.deepEqual(rollingMax(values, 3), [null, null, 8, 8, 10]);
+
+  const expectedStd = Math.sqrt(56 / 9);
+  const actualStd = rollingStdDev(values, 3);
+  assert.equal(actualStd[0], null);
+  assert.equal(actualStd[1], null);
+  assert.ok(Math.abs(actualStd[2] - expectedStd) < 1e-12);
+});
+
+test("stateful rolling primitives reset deterministically", () => {
+  const factories = [
+    () => new RollingSum(3),
+    () => new RollingMean(3),
+    () => new RollingStdDev(3),
+    () => new RollingMin(3),
+    () => new RollingMax(3)
+  ];
+
+  for (const factory of factories) {
+    const rolling = factory();
+    const first = values.map(value => rolling.next(value));
+    rolling.reset();
+    const second = values.map(value => rolling.next(value));
+    assert.deepEqual(second, first);
+  }
+});
+
+test("rolling primitives reject invalid configuration and values", () => {
+  assert.throws(() => new RollingMean(0), /positive integer/);
+  assert.throws(() => new RollingMean(2.5), /positive integer/);
+  assert.throws(() => new RollingMean(Number.NaN), /positive integer/);
+
+  const rolling = new RollingMean(2);
+  assert.throws(() => rolling.next(Number.POSITIVE_INFINITY), /finite number/);
+});
+
+test("rolling extrema handle duplicate values and expired heads", () => {
+  const duplicateValues = [3, 3, 2, 3, 1, 1, 4];
+  assert.deepEqual(rollingMin(duplicateValues, 2), [null, 3, 2, 2, 1, 1, 1]);
+  assert.deepEqual(rollingMax(duplicateValues, 2), [null, 3, 3, 3, 3, 1, 4]);
+});


### PR DESCRIPTION
## Summary

- add an internal shared rolling engine for sum, mean, population standard deviation, minimum, and maximum
- refactor batch SMA, BBANDS, and stateful SMA to reuse the rolling primitives
- preserve warmup, alignment, reset, and golden-output behavior
- add focused tests, deterministic 10k/100k before/after benchmarks, and invariant documentation

## Impact

Fixed-window calculations now have bounded storage and O(1)/amortized O(1) updates. Public exports and indicator contracts remain unchanged.

## Validation

- `npm test` — PASS (11 tests)
- `npm run test:golden` — PASS
- `npm run test:compat:technicalindicators` — PASS (all comparisons)
- `npm run bench` — PASS
- `npm run bench:rolling` — PASS
  - 10k SMA: 3.43x faster
  - 10k BBANDS: 1.32x faster
  - 100k SMA: 2.77x faster
  - 100k BBANDS: 1.20x faster
- `git diff --check` — PASS

The Python compatibility script could not run locally because the available Python is 3.14 and `pandas-ta` pins a `numba` version requiring Python <3.14. The official GitHub Actions gate uses Python 3.12 and remains authoritative.

Closes #18