### PR TITLE
fix(docs): synchronize release documentation for v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased
 
-- Reorganize the README as a concise capability and documentation index.
-- Add focused references for inputs, indicators, crypto utilities, stateful APIs, and compatibility.
-- Synchronize stable-version references and document current v0.3.2 semantics, warmup behavior, limitations, and planned v0.4 corrections.
-
 ## [0.3.3](https://github.com/TDamiao/ta-crypto/compare/v0.3.2...v0.3.3) (2026-07-21)
 
+### Documentation
+
+* Reorganize the README as a concise capability and documentation index.
+* Add focused references for inputs, indicators, crypto utilities, stateful APIs, and compatibility.
+* Document v0.3.3 semantics, warmup behavior, limitations, and planned v0.4 corrections.
+
+### Release automation
+
+* Adopt Release Please and GitHub Actions as the single authority for versions, tags, GitHub Releases, and npm publication.
 
 ### Bug Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing.
 
 ## Current release line
 
-`v0.3.2` is the current stable release.
+`v0.3.4` is the current stable release.
 The v0.4 contribution priority is core hardening:
 1. Financial semantics and numeric validation.
 2. Compatibility and reproducibility depth.
@@ -46,6 +46,20 @@ npm run test:compat:python
 npm run bench
 npm run bench:rolling
 ```
+
+## Release process
+
+GitHub Actions and Release Please are the only release authority. Contributors must not create release commits, tags, GitHub Releases, or npm publications locally.
+
+Use conventional commit prefixes such as `fix:`, `feat:`, and `docs:` so Release Please can classify changes. After a qualifying commit reaches `main`, the workflow creates or updates one Release PR. Merging that PR creates the version commit, tag, and GitHub Release, then runs the release checks and publishes to npm.
+
+Local release work is limited to validation and dry runs:
+
+```bash
+npm run release:check
+```
+
+See [Trust and verification](docs/trust.md) for traceability and failure recovery.
 
 ## Code standards
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/ta-crypto.svg)](https://www.npmjs.com/package/ta-crypto)
 [![CI](https://github.com/TDamiao/ta-crypto/actions/workflows/ci.yml/badge.svg)](https://github.com/TDamiao/ta-crypto/actions/workflows/ci.yml)
 
-Technical analysis indicators and crypto-market utilities for Node.js. The current stable release is `v0.3.2`.
+Technical analysis indicators and crypto-market utilities for Node.js. The current stable release is `v0.3.4`.
 
 ## Install
 
@@ -84,7 +84,7 @@ See [Stateful API](docs/stateful.md) for warmup, parity, and reset behavior.
 
 These items remain roadmap work and must not be treated as current package capabilities.
 
-## Known behavior in v0.3.2
+## Known behavior in v0.3.4
 
 - `percentReturn(values, true)` currently sums periodic simple returns. A controlled breaking correction to compounded cumulative semantics is planned for v0.4 in [issue #27](https://github.com/TDamiao/ta-crypto/issues/27).
 - `logReturn` does not yet reject zero or negative prices; see [issue #28](https://github.com/TDamiao/ta-crypto/issues/28).
@@ -110,7 +110,7 @@ npm test
 
 Additional compatibility and benchmark commands are documented in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Local release commands are not the release authority. The GitHub Actions release flow is being consolidated under [issue #37](https://github.com/TDamiao/ta-crypto/issues/37); local commands should be used only for validation and dry runs.
+GitHub Actions and Release Please are the single release authority. Conventional commits on `main` create or update a Release PR; merging that PR creates the matching tag and GitHub Release, runs the release checks, and publishes to npm. Local commands are limited to validation and dry runs. See [Trust and verification](docs/trust.md) for the complete flow and recovery boundaries.
 
 ## Project references
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,6 +26,15 @@ This roadmap separates released capabilities from planned work. GitHub issues ar
 - Runnable RSI, session VWAP, funding, and external-reference examples.
 - Trust and verification documentation.
 
+### v0.3.3
+
+- Focused package documentation for inputs, indicators, crypto utilities, stateful APIs, compatibility, and trust.
+- Release Please automation as the single authority for versions, tags, GitHub Releases, and npm publication.
+
+### v0.3.4
+
+- Synchronize published version references and document the active Release Please flow and failure recovery.
+
 ## v0.4 focus
 
 The v0.4 release is a core-hardening release, tracked by [issue #21](https://github.com/TDamiao/ta-crypto/issues/21).
@@ -36,7 +45,7 @@ Priorities:
 2. Optimize remaining rolling indicators with parity benchmarks.
 3. Expand stateful coverage with batch parity and deterministic reset.
 4. Broaden independent compatibility evidence.
-5. Make release automation and package publication auditable and secure.
+5. Harden package publication with trusted publishing, provenance, and supply-chain evidence.
 6. Keep documentation synchronized with shipped behavior.
 
 Basic candle resampling is not a v0.4 gate. It remains open for v0.5 or later in [issue #6](https://github.com/TDamiao/ta-crypto/issues/6).

--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -55,7 +55,7 @@ The function returns:
 
 With period `L`, the first potentially non-null regime is at index `2 * L`. Prices feed annualized realized volatility, then a second rolling window standardizes that volatility.
 
-Because this path uses log returns, validate prices as strictly positive in v0.3.2. Domain validation is tracked in [issue #28](https://github.com/TDamiao/ta-crypto/issues/28).
+Because this path uses log returns, validate prices as strictly positive in v0.3.4. Domain validation is tracked in [issue #28](https://github.com/TDamiao/ta-crypto/issues/28).
 
 ## Candle-derived orderflow proxies
 

--- a/docs/indicators.md
+++ b/docs/indicators.md
@@ -1,6 +1,6 @@
 # Indicators
 
-This page documents the batch indicators exported by `ta-crypto@0.3.2`. Outputs are aligned to the input length and use `null` during warmup.
+This page documents the batch indicators exported by `ta-crypto@0.3.4`. Outputs are aligned to the input length and use `null` during warmup.
 
 Use positive integer periods. Cross-API period validation is being standardized in [issue #30](https://github.com/TDamiao/ta-crypto/issues/30).
 
@@ -23,7 +23,7 @@ const trend = adx(high, low, close, 14);
 
 `period` below means the period supplied to the function. The index is zero-based.
 
-| Function | Default parameters | First potentially non-null index in v0.3.2 | Notes |
+| Function | Default parameters | First potentially non-null index in v0.3.4 | Notes |
 | --- | --- | --- | --- |
 | `sma` | 14 | `period - 1` | Simple rolling mean. |
 | `ema` | 14 | `period - 1` | Seeded with the first-period mean. |
@@ -75,7 +75,7 @@ const directional = adx(high, low, close, 14);
 
 ATR and ADX are compared with external libraries only after indicator-specific burn-in. This accounts for initialization differences; it does not mean the first emitted values are interchangeable across libraries. See [Compatibility](compatibility.md).
 
-In v0.3.2, NATR does not reject zero or negative closes before division. Validate close prices as strictly positive until [issue #29](https://github.com/TDamiao/ta-crypto/issues/29) is released.
+In v0.3.4, NATR does not reject zero or negative closes before division. Validate close prices as strictly positive until [issue #29](https://github.com/TDamiao/ta-crypto/issues/29) is released.
 
 ## Returns
 
@@ -91,11 +91,11 @@ const currentArithmeticSum = percentReturn(close, true);
 Important current-version behavior:
 
 - `logReturn(values, true)` sums log returns, which is equivalent to a cumulative log return for valid positive prices.
-- `percentReturn(values, true)` in v0.3.2 sums periodic simple returns. It does not compound them.
+- `percentReturn(values, true)` in v0.3.4 sums periodic simple returns. It does not compound them.
 - v0.4 will make cumulative percent return compound and move arithmetic summation to an explicit API or mode. The boolean signature will be deprecated. See [issue #27](https://github.com/TDamiao/ta-crypto/issues/27).
 - `logReturn` does not yet enforce strictly positive prices. Validate them before calling it; see [issue #28](https://github.com/TDamiao/ta-crypto/issues/28).
 
-For `[100, 110, 121]`, the two 10% periodic returns sum to 20%, while the compounded cumulative return is 21%. v0.3.2's `percentReturn(values, true)` returns the arithmetic 20% path.
+For `[100, 110, 121]`, the two 10% periodic returns sum to 20%, while the compounded cumulative return is 21%. v0.3.4's `percentReturn(values, true)` returns the arithmetic 20% path.
 
 ## Volume
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -1,6 +1,6 @@
 # Inputs and candles
 
-This page describes the input shapes supported by `ta-crypto@0.3.2`.
+This page describes the input shapes supported by `ta-crypto@0.3.4`.
 
 ## Price series
 
@@ -98,7 +98,7 @@ The normalized result has this shape:
 
 For volume-dependent calculations, pass volume explicitly when zero is not the intended meaning. The project is tracking a more explicit cross-API policy in [issue #30](https://github.com/TDamiao/ta-crypto/issues/30).
 
-## Validation in v0.3.2
+## Validation in v0.3.4
 
 - Candle normalization rejects missing or non-finite OHLC values with field and index context.
 - Normalized OHLCV arrays are checked for equal lengths.

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -1,11 +1,11 @@
 # Trust and verification
 
-This page describes the checks and limitations of `ta-crypto@0.3.2`.
+This page describes the checks, release process, and limitations of `ta-crypto@0.3.4`.
 
 ## Current stable release
 
-- Package version: `0.3.2`
-- Git tag: `v0.3.2`
+- Package version: `0.3.4`
+- Git tag: `v0.3.4`
 - Changelog entry: [`CHANGELOG.md`](../CHANGELOG.md)
 
 When verifying an installation, confirm that the npm version, Git tag, release commit, and changelog entry agree.
@@ -60,7 +60,17 @@ Useful evidence:
 - [CI workflow](../.github/workflows/ci.yml)
 - [Compatibility policy](../scripts/compat-policy.json)
 
-The current release automation is tag-triggered. GitHub Actions is the approved future single release authority, tracked in [issue #37](https://github.com/TDamiao/ta-crypto/issues/37). Until that work lands, local release commands must not be treated as the authoritative release path.
+GitHub Actions and [Release Please](../.github/workflows/release-please.yml) are the single release authority:
+
+1. A qualifying conventional commit on `main` creates or updates one Release PR.
+2. The Release PR contains the package version, manifest, lockfile, and changelog changes.
+3. Merging the Release PR creates the matching Git tag and GitHub Release.
+4. The workflow checks out that tag, installs locked dependencies, and runs tests, compatibility checks, and `npm pack --dry-run`.
+5. The workflow publishes to npm only when that exact version is not already present.
+
+Local commands do not create release commits, tags, GitHub Releases, or npm publications. `npm run release:check` is the supported local validation and dry-run entry point.
+
+If validation or npm publication fails after the tag and GitHub Release exist, fix the external cause and rerun only the failed GitHub Actions jobs. The npm version check prevents a rerun from attempting to overwrite an existing version. Published npm versions and Git tags are immutable recovery boundaries; corrections require a new patch release.
 
 npm Trusted Publishing, provenance, and SBOM work is tracked in [issue #41](https://github.com/TDamiao/ta-crypto/issues/41). Do not claim those controls are active before that issue is completed and verified.
 
@@ -68,7 +78,7 @@ npm Trusted Publishing, provenance, and SBOM work is tracked in [issue #41](http
 
 - Some external libraries use different warmup and initialization conventions.
 - External compatibility currently covers a subset of exported indicators and fixtures.
-- `percentReturn(values, true)` has arithmetic-sum semantics in v0.3.2; the approved v0.4 correction is tracked in [issue #27](https://github.com/TDamiao/ta-crypto/issues/27).
+- `percentReturn(values, true)` has arithmetic-sum semantics in v0.3.4; the approved v0.4 correction is tracked in [issue #27](https://github.com/TDamiao/ta-crypto/issues/27).
 - Log-return and NATR financial-domain validation is being hardened in [#28](https://github.com/TDamiao/ta-crypto/issues/28) and [#29](https://github.com/TDamiao/ta-crypto/issues/29).
 - Candle-derived orderflow functions are not L2/L3 order-book analytics.
 - Backtesting, built-in strategies, screeners, broad adapters, resampling, and complete multi-timeframe support are not current features.


### PR DESCRIPTION
## What changed

- synchronize active release references with v0.3.4
- document Release Please as the single release authority
- document npm publication recovery and immutable release boundaries
- move the v0.3.3 documentation and automation notes into the released changelog

## Why

The v0.3.3 package shipped documentation that still identified v0.3.2 and described the retired tag-triggered release flow. This patch keeps the npm README and packaged docs aligned with the release artifacts users install.

## Validation

- npm run release:check
- TA-Lib compatibility with Python 3.12
- git diff --check
- verified README and docs are included by npm pack --dry-run