### PR TITLE
docs: add package status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # ta-crypto
 
 [![npm version](https://img.shields.io/npm/v/ta-crypto.svg)](https://www.npmjs.com/package/ta-crypto)
+[![npm downloads](https://img.shields.io/npm/dm/ta-crypto.svg)](https://www.npmjs.com/package/ta-crypto)
+[![TypeScript types](https://img.shields.io/npm/types/ta-crypto.svg)](https://www.npmjs.com/package/ta-crypto)
 [![CI](https://github.com/TDamiao/ta-crypto/actions/workflows/ci.yml/badge.svg)](https://github.com/TDamiao/ta-crypto/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/ta-crypto.svg)](LICENSE)
 
 Technical analysis indicators and crypto-market utilities for Node.js. The current stable release is `v0.3.4`.
 


### PR DESCRIPTION
## What changed

- add npm monthly downloads badge
- add built-in TypeScript declarations badge
- add npm license badge linked to LICENSE

## Why

The README currently exposes only the package version and CI status. These badges add useful package metadata without claiming unsupported coverage, provenance, or security guarantees.

## Validation

- all Shields.io endpoints return HTTP 200 with SVG content
- git diff --check